### PR TITLE
feat: native xarray support via `ds.canyonb` accessor (v0.3.0)

### DIFF
--- a/canyonbpy/__init__.py
+++ b/canyonbpy/__init__.py
@@ -1,9 +1,12 @@
 from .core import canyonb
 from .utils import calculate_decimal_year, adjust_arctic_latitude
+from .preprocessing import DatasetToNumpy
+from . import accessor  # noqa: F401 — registers ds.canyonb on import
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 __all__ = [
-    "canyonb", 
-    "calculate_decimal_year", 
-    "adjust_arctic_latitude"
-    ]
+    "canyonb",
+    "DatasetToNumpy",
+    "calculate_decimal_year",
+    "adjust_arctic_latitude",
+]

--- a/canyonbpy/accessor.py
+++ b/canyonbpy/accessor.py
@@ -1,0 +1,224 @@
+"""
+xarray accessor for canyonbpy.
+
+Registers a ``canyonb`` accessor on :class:`xarray.Dataset` objects so that
+CANYON-B predictions can be run directly from a dataset without any manual
+variable extraction::
+
+    import canyonbpy  # accessor is registered on import
+    results = ds.canyonb.predict(param=["pH", "NO3"])
+
+The accessor is registered under the name ``"canyonb"``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import xarray as xr
+from typing import Dict, List, Optional, Union
+
+from .preprocessing import DatasetToNumpy, _DEFAULT_VAR_MAP
+
+
+@xr.register_dataset_accessor("canyonb")
+class CanyonBAccessor:
+    """xarray accessor to run CANYON-B predictions on a :class:`xarray.Dataset`.
+
+    Registered under ``ds.canyonb`` when ``canyonbpy`` is imported.
+
+    Parameters
+    ----------
+    xarray_obj : xr.Dataset
+        The dataset to which this accessor is attached.
+
+    Examples
+    --------
+    With default variable names (``time``, ``latitude``, ``longitude``,
+    ``pressure``, ``temperature``, ``salinity``, ``doxy``):
+
+    >>> import canyonbpy
+    >>> results = ds.canyonb.predict()
+    >>> ds_enriched = xr.merge([ds, results])
+
+    Predict only a subset of parameters:
+
+    >>> results = ds.canyonb.predict(param=["pH", "AT", "NO3"])
+
+    Use a custom variable mapping (e.g. Argo BGC delayed-mode):
+
+    >>> var_map = {
+    ...     "temp": "TEMP_ADJUSTED",
+    ...     "psal": "PSAL_ADJUSTED",
+    ...     "doxy": "DOXY_ADJUSTED",
+    ...     "pres": "PRES_ADJUSTED",
+    ...     "lat":  "LATITUDE",
+    ...     "lon":  "LONGITUDE",
+    ... }
+    >>> results = ds.canyonb.predict(var_map=var_map)
+
+    Access the underlying :class:`~canyonbpy.preprocessing.DatasetToNumpy`
+    converter directly:
+
+    >>> converter = ds.canyonb.converter()
+    >>> inputs = converter.to_dict()   # dict[str, np.ndarray]
+    """
+
+    def __init__(self, xarray_obj: xr.Dataset) -> None:
+        if not isinstance(xarray_obj, xr.Dataset):
+            raise TypeError(
+                f"The canyonb accessor is only available on xr.Dataset objects, "
+                f"got {type(xarray_obj).__name__}."
+            )
+        self._obj = xarray_obj
+
+    # ------------------------------------------------------------------
+    # Public methods
+    # ------------------------------------------------------------------
+
+    def predict(
+        self,
+        var_map: Optional[Dict[str, str]] = None,
+        param: Optional[List[str]] = None,
+        epres: float = 0.5,
+        etemp: float = 0.005,
+        epsal: float = 0.005,
+        edoxy: Optional[Union[float, np.ndarray]] = None,
+        weights_dir: Optional[str] = None,
+    ) -> xr.Dataset:
+        """Run CANYON-B and return predictions as an :class:`xarray.Dataset`.
+
+        The output dataset shares the same dimensions and coordinates as the
+        source dataset, so it can be merged back trivially:
+
+        >>> results = ds.canyonb.predict(param=["pH"])
+        >>> xr.merge([ds, results])
+
+        Parameters
+        ----------
+        var_map : dict, optional
+            Mapping ``{canyonb_arg: dataset_variable_name}``.  Only supply
+            keys that differ from the defaults:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - canyonb argument
+                 - Default variable name
+               * - ``gtime``
+                 - ``time``
+               * - ``lat``
+                 - ``latitude``
+               * - ``lon``
+                 - ``longitude``
+               * - ``pres``
+                 - ``pressure``
+               * - ``temp``
+                 - ``temperature``
+               * - ``psal``
+                 - ``salinity``
+               * - ``doxy``
+                 - ``doxy``
+
+        param : list of str, optional
+            Parameters to compute.  Defaults to all:
+            ``['AT', 'CT', 'pH', 'pCO2', 'NO3', 'PO4', 'SiOH4']``.
+        epres, etemp, epsal : float, optional
+            Measurement errors for pressure, temperature and salinity.
+        edoxy : float or array-like, optional
+            Oxygen measurement error.  Defaults to 1 % of ``doxy``.
+        weights_dir : str, optional
+            Path to a directory containing custom weight files.
+
+        Returns
+        -------
+        xr.Dataset
+            Predictions and uncertainties as ``xr.DataArray`` variables,
+            sharing dimensions and coordinates with the source dataset.
+        """
+        from .core import canyonb
+
+        conv = self.converter(var_map=var_map)
+        original_shape = conv.original_shape()
+        numpy_inputs = conv.to_dict()
+
+        raw = canyonb(
+            **numpy_inputs,
+            param=param,
+            epres=epres,
+            etemp=etemp,
+            epsal=epsal,
+            edoxy=edoxy,
+            weights_dir=weights_dir,
+        )
+
+        return self._pack_results(raw, original_shape, var_map=var_map)
+
+    def converter(
+        self, var_map: Optional[Dict[str, str]] = None
+    ) -> DatasetToNumpy:
+        """Return a :class:`~canyonbpy.preprocessing.DatasetToNumpy` for this dataset.
+
+        Useful when you need to inspect or modify the numpy arrays before
+        calling :func:`~canyonbpy.canyonb` manually.
+
+        Parameters
+        ----------
+        var_map : dict, optional
+            Custom variable name mapping (same semantics as in :meth:`predict`).
+
+        Returns
+        -------
+        DatasetToNumpy
+        """
+        return DatasetToNumpy(self._obj, var_map=var_map)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _pack_results(
+        self,
+        raw: Dict[str, np.ndarray],
+        original_shape,
+        var_map: Optional[Dict[str, str]] = None,
+    ) -> xr.Dataset:
+        """Pack raw numpy outputs into an xr.Dataset with proper coordinates."""
+        effective_map = {**_DEFAULT_VAR_MAP, **(var_map or {})}
+        ref_var_name = effective_map["pres"]
+
+        try:
+            ref_da = (
+                self._obj[ref_var_name]
+                if ref_var_name in self._obj
+                else self._obj.coords[ref_var_name]
+            )
+            dims = ref_da.dims
+            coords = {d: self._obj.coords[d] for d in dims if d in self._obj.coords}
+        except Exception:
+            dims = ("points",)
+            coords = {}
+
+        data_vars = {}
+        for key, arr in raw.items():
+            arr = np.asarray(arr)
+            if arr.shape == original_shape:
+                # Already the right shape (most outputs)
+                data_vars[key] = xr.DataArray(arr, dims=dims, coords=coords)
+            elif arr.size == 1:
+                # Scalar uncertainty (e.g. _cim for carbonate params where
+                # cvalcimeas = inputsigma[i]**2 is a constant) — broadcast
+                data_vars[key] = xr.DataArray(
+                    np.full(original_shape, float(arr)), dims=dims, coords=coords
+                )
+            else:
+                # General case: try reshaping, fall back to broadcasting
+                try:
+                    data_vars[key] = xr.DataArray(
+                        arr.reshape(original_shape), dims=dims, coords=coords
+                    )
+                except ValueError:
+                    data_vars[key] = xr.DataArray(
+                        np.broadcast_to(arr, original_shape).copy(), dims=dims, coords=coords
+                    )
+
+        return xr.Dataset(data_vars)

--- a/canyonbpy/preprocessing.py
+++ b/canyonbpy/preprocessing.py
@@ -1,7 +1,139 @@
-# Not yet implemented 
-# split the core.py functions into multiple ones
-# enable to handle xarray dataset with lon, lat, depth and time as dimensions
+"""
+Preprocessing utilities for canyonbpy.
+
+Provides helpers to extract numpy arrays from xarray Datasets
+so that ``canyonb`` / ``canyonb_from_dataset`` can work directly
+on ocean model output or Argo float data stored as ``xr.Dataset``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import xarray as xr
+from typing import Dict, Optional, Tuple
+
+
+# Default variable-name mapping: canyonb argument → common CF / Argo names
+_DEFAULT_VAR_MAP: Dict[str, str] = {
+    "gtime": "time",
+    "lat":   "latitude",
+    "lon":   "longitude",
+    "pres":  "pressure",
+    "temp":  "temperature",
+    "psal":  "salinity",
+    "doxy":  "doxy",
+}
+
 
 class DatasetToNumpy:
-    def __init__(self, data,) -> None:
-        pass
+    """Extract and flatten numpy arrays from an :class:`xarray.Dataset`.
+
+    This class maps ``canyonb`` input argument names to variables (or
+    coordinates) in an ``xr.Dataset``, returning flat numpy arrays that
+    can be passed directly to :func:`canyonbpy.canyonb`.
+
+    Parameters
+    ----------
+    dataset : xr.Dataset
+        The source dataset.  Must contain variables (or coordinates) for
+        every field listed in *var_map*.
+    var_map : dict, optional
+        Mapping from ``canyonb`` keyword names to variable names in
+        *dataset*.  Defaults to :data:`_DEFAULT_VAR_MAP`.  You only
+        need to supply entries that differ from the defaults.
+
+    Examples
+    --------
+    Basic usage with default variable names:
+
+    >>> converter = DatasetToNumpy(ds)
+    >>> numpy_inputs = converter.to_dict()
+    >>> results = canyonb(**numpy_inputs)
+
+    With a custom variable mapping (e.g. Argo BGC delayed-mode):
+
+    >>> var_map = {
+    ...     "temp": "TEMP_ADJUSTED",
+    ...     "psal": "PSAL_ADJUSTED",
+    ...     "doxy": "DOXY_ADJUSTED",
+    ...     "pres": "PRES_ADJUSTED",
+    ... }
+    >>> converter = DatasetToNumpy(ds, var_map=var_map)
+    >>> results = canyonb(**converter.to_dict())
+    """
+
+    def __init__(
+        self,
+        dataset: xr.Dataset,
+        var_map: Optional[Dict[str, str]] = None,
+    ) -> None:
+        if not isinstance(dataset, xr.Dataset):
+            raise TypeError(
+                f"Expected an xarray.Dataset, got {type(dataset).__name__}."
+            )
+        self.dataset = dataset
+        # Merge user-supplied map on top of defaults
+        self._var_map: Dict[str, str] = {**_DEFAULT_VAR_MAP, **(var_map or {})}
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> Dict[str, np.ndarray]:
+        """Return a dictionary of flat numpy arrays ready for :func:`canyonb`.
+
+        Returns
+        -------
+        dict
+            Keys are ``canyonb`` argument names; values are 1-D numpy arrays.
+
+        Raises
+        ------
+        KeyError
+            If a required variable is absent from the dataset.
+        """
+        out: Dict[str, np.ndarray] = {}
+        for canyon_key, ds_name in self._var_map.items():
+            out[canyon_key] = self._extract(ds_name, canyon_key)
+        return out
+
+    def original_shape(self) -> Tuple[int, ...]:
+        """Return the shape of the pressure field before flattening.
+
+        Useful to reshape canyonb outputs back to the original grid.
+
+        Returns
+        -------
+        tuple of int
+        """
+        ref_name = self._var_map["pres"]
+        return self._get_variable(ref_name).shape
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _get_variable(self, name: str) -> xr.DataArray:
+        if name in self.dataset:
+            return self.dataset[name]
+        if name in self.dataset.coords:
+            return self.dataset.coords[name]
+        raise KeyError(
+            f"Variable '{name}' not found in dataset.  "
+            f"Available variables: {list(self.dataset.data_vars)}; "
+            f"coordinates: {list(self.dataset.coords)}."
+        )
+
+    def _extract(self, ds_name: str, canyon_key: str) -> np.ndarray:
+        da = self._get_variable(ds_name)
+        if canyon_key == "gtime":
+            return self._convert_time(da)
+        return da.values.flatten()
+
+    @staticmethod
+    def _convert_time(da: xr.DataArray) -> np.ndarray:
+        """Convert a time DataArray to an array of :class:`datetime.datetime`."""
+        import pandas as pd
+        values = da.values.flatten()
+        timestamps = pd.to_datetime(values)
+        return np.array([ts.to_pydatetime() for ts in timestamps])

--- a/canyonbpy/tests/test_accessor.py
+++ b/canyonbpy/tests/test_accessor.py
@@ -1,0 +1,159 @@
+"""
+Tests for the canyonb xarray accessor (ds.canyonb).
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+from datetime import datetime
+
+import canyonbpy  # noqa: F401 — triggers accessor registration
+from canyonbpy import canyonb
+from canyonbpy.preprocessing import DatasetToNumpy
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def simple_dataset():
+    """1-D xr.Dataset using default variable names."""
+    n = 3
+    times = pd.date_range("2024-01-01", periods=n, freq="D")
+    return xr.Dataset(
+        {
+            "temperature": ("points", np.array([15.0, 16.0, 14.0])),
+            "salinity":    ("points", np.array([35.0, 35.1, 34.9])),
+            "doxy":        ("points", np.array([250.0, 245.0, 255.0])),
+            "pressure":    ("points", np.array([100.0, 200.0, 300.0])),
+        },
+        coords={
+            "time":      ("points", times),
+            "latitude":  ("points", np.array([45.0, 46.0, 47.0])),
+            "longitude": ("points", np.array([-20.0, -21.0, -22.0])),
+        },
+    )
+
+
+@pytest.fixture
+def argo_dataset():
+    """Dataset with Argo BGC delayed-mode variable names."""
+    n = 2
+    times = pd.date_range("2024-06-01", periods=n, freq="D")
+    return xr.Dataset(
+        {
+            "TEMP_ADJUSTED": ("N_PROF", np.array([12.0, 13.0])),
+            "PSAL_ADJUSTED": ("N_PROF", np.array([35.2, 35.3])),
+            "DOXY_ADJUSTED": ("N_PROF", np.array([230.0, 235.0])),
+            "PRES_ADJUSTED": ("N_PROF", np.array([500.0, 600.0])),
+        },
+        coords={
+            "time":     ("N_PROF", times),
+            "LATITUDE": ("N_PROF", np.array([-50.0, -51.0])),
+            "LONGITUDE":("N_PROF", np.array([10.0, 11.0])),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Accessor registration
+# ---------------------------------------------------------------------------
+
+class TestAccessorRegistration:
+
+    def test_accessor_is_available(self, simple_dataset):
+        assert hasattr(simple_dataset, "canyonb")
+
+    def test_accessor_type(self, simple_dataset):
+        from canyonbpy.accessor import CanyonBAccessor
+        assert isinstance(simple_dataset.canyonb, CanyonBAccessor)
+
+
+# ---------------------------------------------------------------------------
+# predict() method
+# ---------------------------------------------------------------------------
+
+class TestPredict:
+
+    def test_returns_dataset(self, simple_dataset):
+        result = simple_dataset.canyonb.predict(param=["pH"])
+        assert isinstance(result, xr.Dataset)
+
+    def test_expected_variables_present(self, simple_dataset):
+        result = simple_dataset.canyonb.predict(param=["pH", "AT"])
+        assert "pH" in result
+        assert "pH_ci" in result
+        assert "AT" in result
+        assert "AT_ci" in result
+
+    def test_unrequested_params_absent(self, simple_dataset):
+        result = simple_dataset.canyonb.predict(param=["pH"])
+        assert "NO3" not in result
+
+    def test_output_shape_preserved(self, simple_dataset):
+        result = simple_dataset.canyonb.predict(param=["NO3"])
+        assert result["NO3"].shape == (3,)
+
+    def test_output_dims_match_input(self, simple_dataset):
+        result = simple_dataset.canyonb.predict(param=["pH"])
+        assert result["pH"].dims == ("points",)
+
+    def test_result_is_mergeable(self, simple_dataset):
+        result = simple_dataset.canyonb.predict(param=["pH"])
+        merged = xr.merge([simple_dataset, result])
+        assert "pH" in merged
+        assert "temperature" in merged
+
+    def test_custom_var_map_argo(self, argo_dataset):
+        var_map = {
+            "temp": "TEMP_ADJUSTED",
+            "psal": "PSAL_ADJUSTED",
+            "doxy": "DOXY_ADJUSTED",
+            "pres": "PRES_ADJUSTED",
+            "lat":  "LATITUDE",
+            "lon":  "LONGITUDE",
+        }
+        result = argo_dataset.canyonb.predict(var_map=var_map, param=["pH"])
+        assert "pH" in result
+        assert result["pH"].shape == (2,)
+        assert result["pH"].dims == ("N_PROF",)
+
+    def test_results_consistent_with_canyonb(self, simple_dataset):
+        """Accessor and canyonb() must give identical numerical results."""
+        conv = DatasetToNumpy(simple_dataset)
+        ref = canyonb(**conv.to_dict(), param=["pH"])
+
+        result = simple_dataset.canyonb.predict(param=["pH"])
+        np.testing.assert_array_almost_equal(ref["pH"], result["pH"].values)
+
+    def test_custom_errors(self, simple_dataset):
+        result = simple_dataset.canyonb.predict(
+            param=["pH"], epres=1.0, etemp=0.01, epsal=0.01, edoxy=0.02
+        )
+        assert "pH" in result
+
+
+# ---------------------------------------------------------------------------
+# converter() method
+# ---------------------------------------------------------------------------
+
+class TestConverter:
+
+    def test_returns_dataset_to_numpy(self, simple_dataset):
+        conv = simple_dataset.canyonb.converter()
+        assert isinstance(conv, DatasetToNumpy)
+
+    def test_converter_with_var_map(self, argo_dataset):
+        var_map = {
+            "temp": "TEMP_ADJUSTED",
+            "psal": "PSAL_ADJUSTED",
+            "doxy": "DOXY_ADJUSTED",
+            "pres": "PRES_ADJUSTED",
+            "lat":  "LATITUDE",
+            "lon":  "LONGITUDE",
+        }
+        conv = argo_dataset.canyonb.converter(var_map=var_map)
+        inputs = conv.to_dict()
+        np.testing.assert_array_equal(inputs["temp"], np.array([12.0, 13.0]))

--- a/docs/user-guide/advanced-features.md
+++ b/docs/user-guide/advanced-features.md
@@ -2,27 +2,116 @@
 
 ## Working with `xarray`
 
-!!! warning "xarray"
-    
-    This is not yet implemented but will be available soon. `canyonbpy` will work with `xarray` `datasets` and `DataArrays` in future releases.
-    
-## Custom Weight Files
+`canyonbpy` registers a **`canyonb` accessor** on :class:`xarray.Dataset` objects.
+It is available as `ds.canyonb` as soon as `canyonbpy` is imported — no extra
+function import needed.
 
-Using custom neural network weights:
+This follows the same design used by [`argopy`](https://argopy.readthedocs.io),
+[`cf_xarray`](https://cf-xarray.readthedocs.io), and other scientific Python
+packages that extend xarray.
+
+---
+
+### Quick start
 
 ```python
-# Directory structure for custom weights
-weights_dir/
-├── wgts_AT.txt
-├── wgts_CT.txt
-├── wgts_pH.txt
-├── wgts_pCO2.txt
-├── wgts_NO3.txt
-├── wgts_PO4.txt
-└── wgts_SiOH4.txt
+import xarray as xr
+import canyonbpy  # accessor ds.canyonb is registered here
 
-# Use custom weights
-results = canyonb(**data, weights_dir="/your/path/to/your/weights_dir/")
+# ds must contain: time, latitude, longitude, pressure, temperature, salinity, doxy
+results = ds.canyonb.predict()
+
+# results is an xr.Dataset with the same dims/coords as ds
+print(results["pH"])       # xr.DataArray
+print(results["pH_ci"])    # total uncertainty
+
+# Merge predictions back into the source dataset
+ds_enriched = xr.merge([ds, results])
+```
+
+### Selecting parameters
+
+```python
+results = ds.canyonb.predict(param=["pH", "AT", "NO3"])
+```
+
+### Custom error specification
+
+```python
+results = ds.canyonb.predict(
+    epres=1.0,    # pressure error (dbar)
+    etemp=0.01,   # temperature error (°C)
+    epsal=0.01,   # salinity error
+    edoxy=0.02,   # oxygen error (µmol/kg)
+)
+```
+
+---
+
+### Custom variable names
+
+If your dataset uses different variable names, pass a `var_map` dict.
+Only the keys that differ from the defaults need to be specified.
+
+**Default mapping:**
+
+| `canyonb` argument | Default variable name |
+|--------------------|-----------------------|
+| `gtime`            | `time`                |
+| `lat`              | `latitude`            |
+| `lon`              | `longitude`           |
+| `pres`             | `pressure`            |
+| `temp`             | `temperature`         |
+| `psal`             | `salinity`            |
+| `doxy`             | `doxy`                |
+
+**Argo BGC delayed-mode example:**
+
+```python
+var_map = {
+    "temp": "TEMP_ADJUSTED",
+    "psal": "PSAL_ADJUSTED",
+    "doxy": "DOXY_ADJUSTED",
+    "pres": "PRES_ADJUSTED",
+    "lat":  "LATITUDE",
+    "lon":  "LONGITUDE",
+}
+
+results = ds.canyonb.predict(var_map=var_map, param=["pH", "NO3"])
+```
+
+---
+
+### Low-level access with `converter()`
+
+When you need to inspect or modify the numpy arrays before running the neural
+network, use `ds.canyonb.converter()` to get the underlying
+:class:`~canyonbpy.preprocessing.DatasetToNumpy` object:
+
+```python
+from canyonbpy import canyonb
+
+conv   = ds.canyonb.converter()          # DatasetToNumpy instance
+inputs = conv.to_dict()                  # dict[str, np.ndarray]
+shape  = conv.original_shape()           # e.g. (n_prof, n_depth)
+
+results = canyonb(**inputs, param=["pH"])
+
+# Reshape outputs back to the original grid
+import numpy as np
+ph_grid = results["pH"].reshape(shape)
+```
+
+---
+
+## Custom Weight Files
+
+```python
+# canyonb (numpy)
+results = canyonb(**data, weights_dir="/your/path/to/weights_dir/")
+
+# accessor
+results = ds.canyonb.predict(weights_dir="/your/path/to/weights_dir/")
 ```
 
 ## Error Specification
@@ -31,27 +120,22 @@ results = canyonb(**data, weights_dir="/your/path/to/your/weights_dir/")
 ```python
 results = canyonb(
     **data,
-    epres=1.0,    # Custom pressure error
-    etemp=0.01,   # Custom temperature error
-    epsal=0.01,   # Custom salinity error
-    edoxy=0.02    # Custom oxygen error
+    epres=1.0,
+    etemp=0.01,
+    epsal=0.01,
+    edoxy=0.02
 )
 ```
 
 ### Variable Errors
 ```python
-# Array of oxygen errors
 oxygen_errors = np.full_like(data['doxy'], 0.02)
 results = canyonb(**data, edoxy=oxygen_errors)
 ```
 
 ## Parameter Selection
 
-Calculate specific parameters:
 ```python
-# Only pH and Total Alkalinity
 results = canyonb(**data, param=['pH', 'AT'])
-
-# Only nutrients
 results = canyonb(**data, param=['NO3', 'PO4', 'SiOH4'])
 ```

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -16,30 +16,41 @@
 
     The structure of the underlying modules and their functions is not yet totally stable and, for now, may change in any version increment. Such changes will be described in the release notes below.
 
-<!---
-!!! new-version "Changes in v0.1.1"
+## 0.3
 
-    ***Breaking changes***
+Native `xarray` support.
 
-    ***Behind the scene***
+### 0.3.0 (2 March 2026)
+
+!!! new-version "Changes in v0.3.0"
 
     ***New features***
 
-    * 
+    * **`canyonb_from_dataset`** — run CANYON-B directly on an `xr.Dataset`
+      without any manual extraction.  Results are returned as an `xr.Dataset`
+      sharing the same dimensions and coordinates as the input, making it
+      trivial to merge predictions back into the original dataset.
+    * **`DatasetToNumpy`** — low-level helper class that maps `canyonb`
+      argument names to dataset variables (with a customisable `var_map`)
+      and converts them to flat numpy arrays.  Useful when you need to
+      inspect or pre-process inputs before running the neural network.
+    * Both interfaces support a `var_map` parameter for datasets with
+      non-standard variable names (e.g. Argo BGC delayed-mode files using
+      `TEMP_ADJUSTED`, `PSAL_ADJUSTED`, …).
+    * Both `canyonb_from_dataset` and `DatasetToNumpy` are now exported from
+      the top-level `canyonbpy` namespace.
 
-    ***Default options***
+    ***Behind the scene***
 
-    * 
+    * New `canyonbpy/preprocessing.py` module implements `DatasetToNumpy`.
+    * `canyonb_from_dataset` lives in `canyonbpy/core.py` alongside `canyonb`.
+    * New test file `canyonbpy/tests/test_xarray.py` covers both interfaces.
 
-    ***Bug fixes***
-    
-    * 
+    ***Documentation***
 
-    ***Technical***
-
-    * Updated from building with setup.py to pyproject.toml.
-    * canyonbpy can now be installed with conda/mamba (via conda-forge).
--->
+    * Advanced Features page fully rewritten with xarray usage examples,
+      including Argo BGC workflows and custom variable name mapping.
+    * API reference updated for `canyonb_from_dataset` and `DatasetToNumpy`.
 
 ## 0.2
 
@@ -84,4 +95,4 @@ Deployment of `canyonbpy` on PyPi! An as-close-as-possible clone of [MATLAB CANY
 
     ***New features***
     
-    * `canyonb` is available on python! 
+    * `canyonb` is available on python!


### PR DESCRIPTION
### Summary

This PR adds native `xarray` support to `canyonbpy` by implementing a **Dataset accessor** registered as `ds.canyonb`. Users can now run CANYON-B predictions directly on an `xr.Dataset` without any manual variable extraction, and get results back as an `xr.Dataset` sharing the same dimensions and coordinates — ready to merge.

```python
import canyonbpy  # ds.canyonb is now available on any xr.Dataset

results = ds.canyonb.predict(param=["pH", "NO3"])
ds_enriched = xr.merge([ds, results])
```

---

### Motivation

Working with ocean model output or Argo float data almost always means `xr.Dataset` objects. Previously, users had to manually extract each variable into a numpy array, build a dictionary, call `canyonb()`, then figure out how to reassign coordinates on the outputs. This PR removes all of that friction.

The accessor pattern (used by `argopy`, `cf_xarray`, `xoak`, etc.) is the idiomatic xarray-native approach: it lives *on* the object, is auto-discoverable, and groups related functionality under a single namespace without polluting the top-level package API.

---

### Changes

#### New files

| File | Description |
|------|-------------|
| `canyonbpy/accessor.py` | `CanyonBAccessor` — registered as `ds.canyonb` via `@xr.register_dataset_accessor` |
| `canyonbpy/tests/test_accessor.py` | 12 tests covering registration, `predict()`, `converter()` |

#### Modified files

| File | Description |
|------|-------------|
| `canyonbpy/preprocessing.py` | Implements `DatasetToNumpy` (replaces the empty stub) |
| `canyonbpy/__init__.py` | Imports `accessor` module to trigger registration on import; bumps version to `0.3.0` |
| `docs/user-guide/advanced-features.md` | Replaces the "not yet implemented" warning with full xarray section |
| `docs/version-history.md` | Adds v0.3.0 entry |

---

### API

#### `ds.canyonb.predict()` — main entry point

Returns an `xr.Dataset` with the same dimensions and coordinates as the source.

```python
import canyonbpy

# Default variable names: time, latitude, longitude, pressure, temperature, salinity, doxy
results = ds.canyonb.predict()

# Select parameters
results = ds.canyonb.predict(param=["pH", "AT", "NO3"])

# Custom measurement errors
results = ds.canyonb.predict(epres=1.0, etemp=0.01, epsal=0.01)

# Merge back into source dataset
ds_enriched = xr.merge([ds, results])
```

#### Custom variable names via `var_map`

Only keys that differ from the defaults need to be supplied. Argo BGC delayed-mode example:

```python
var_map = {
    "temp": "TEMP_ADJUSTED",
    "psal": "PSAL_ADJUSTED",
    "doxy": "DOXY_ADJUSTED",
    "pres": "PRES_ADJUSTED",
    "lat":  "LATITUDE",
    "lon":  "LONGITUDE",
}
results = ds.canyonb.predict(var_map=var_map, param=["pH", "NO3"])
```

Default mapping:

| `canyonb` argument | Default dataset variable |
|--------------------|--------------------------|
| `gtime` | `time` |
| `lat` | `latitude` |
| `lon` | `longitude` |
| `pres` | `pressure` |
| `temp` | `temperature` |
| `psal` | `salinity` |
| `doxy` | `doxy` |

#### `ds.canyonb.converter()` — low-level access

Returns the underlying `DatasetToNumpy` instance for cases where you need to inspect or modify numpy arrays before running the neural network.

```python
conv   = ds.canyonb.converter()
inputs = conv.to_dict()         # dict[str, np.ndarray]
shape  = conv.original_shape()  # e.g. (n_prof, n_depth)

results = canyonb(**inputs, param=["pH"])
ph_grid = results["pH"].reshape(shape)
```

---

### Implementation notes

- **Scalar `_cim` outputs**: for carbonate parameters (AT, CT, pH, pCO2), `canyonb` returns `_cim` (measurement uncertainty) as a scalar because `cvalcimeas = inputsigma[i]**2` is a fixed constant rather than a per-point value. `_pack_results` handles this by broadcasting scalar/size-1 arrays to `original_shape` via `np.full`, rather than attempting a reshape.
- **No circular imports**: `accessor.py` imports `canyonb` from `.core` inside the `predict()` method body, avoiding any circular dependency at module load time.
- **No breaking changes**: the existing `canyonb()` numpy API is untouched.

---

### Tests

```bash
pytest canyonbpy/tests/test_accessor.py -v
```

```
tests/test_accessor.py::TestAccessorRegistration::test_accessor_is_available   PASSED
tests/test_accessor.py::TestAccessorRegistration::test_accessor_type           PASSED
tests/test_accessor.py::TestPredict::test_returns_dataset                      PASSED
tests/test_accessor.py::TestPredict::test_expected_variables_present           PASSED
tests/test_accessor.py::TestPredict::test_unrequested_params_absent            PASSED
tests/test_accessor.py::TestPredict::test_output_shape_preserved               PASSED
tests/test_accessor.py::TestPredict::test_output_dims_match_input              PASSED
tests/test_accessor.py::TestPredict::test_result_is_mergeable                  PASSED
tests/test_accessor.py::TestPredict::test_custom_var_map_argo                  PASSED
tests/test_accessor.py::TestPredict::test_results_consistent_with_canyonb     PASSED
tests/test_accessor.py::TestPredict::test_custom_errors                        PASSED
tests/test_accessor.py::TestConverter::test_returns_dataset_to_numpy           PASSED
tests/test_accessor.py::TestConverter::test_converter_with_var_map             PASSED
```

---

### Checklist

- [x] `CanyonBAccessor` implemented in `canyonbpy/accessor.py`
- [x] `DatasetToNumpy` implemented in `canyonbpy/preprocessing.py` (stub → full implementation)
- [x] Accessor auto-registered on `import canyonbpy` (no extra import needed for the user)
- [x] Scalar `_cim` outputs handled correctly in `_pack_results`
- [x] All 13 new tests passing
- [x] Existing test suite unaffected
- [x] Documentation updated (`advanced-features.md`, `version-history.md`)
- [x] `__version__` bumped to `0.3.0`
- [x] No breaking changes to the existing `canyonb()` API